### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-#sublime-marko
+# sublime-marko
+
 Syntax highlighting and several auto-complete snippets for
 [Marko-js](https://github.com/marko-js/marko) in Sublime Text. Syntax highlight
 taken from the official
 [TextMate bundle for the Marko templating language](https://github.com/marko-js/marko-tmbundle).
 
-##Installation
-####Package Control (recommended)
+## Installation
+#### Package Control (recommended)
 Install [Package Control](https://packagecontrol.io/) and look for the package
 called `Marko`.
 
-####Manual
+#### Manual
 You'll need to copy `Marko.tmLanguage` and `Marko.sublime-completions` into your
  `Sublime Text/Packages/User` folder (where you store your snippets).
 
-##Props
+## Props
 - [Official TextMate bundle for the Marko templating language](https://github.com/marko-js/marko-tmbundle)
 - [Marko's Atom language definitions](https://github.com/marko-js/atom-language-marko)
 - [AAAPackageDev](https://bitbucket.org/guillermooo/aaapackagedev)


### PR DESCRIPTION
Headings without space after `#` is not recognized on GitHub